### PR TITLE
Bump guava 29.0-jre to 31.0.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>29.0-jre</version>
+                <version>31.0.1-jre</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
# Remediation
Upgrade com.google.guava:guava to version 31.0.1-jre:


# Details
CVE-2020-8908
low severity
```
Vulnerable versions: <= 29.0
Patched version: 30.0-jre
A temp directory creation vulnerability exist in Guava versions prior to 30.0 allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava com.google.common.io.Files.createTempDir(). The permissions granted to the directory created default to the standard unix-like /tmp ones, leaving the files open. We recommend updating Guava to version 30.0 or later, or update to Java 7 or later, or to explicitly change the permissions after the creation of the directory if neither are possible.
```