### PR TITLE
replaces log4j classic with most recent logback

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,21 @@
             <artifactId>vavr</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
         <!-- Library for unit tests -->
         <dependency>
             <groupId>junit</groupId>

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} [%C{36}#%M\(\)] - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="com.github.jasjisdo" level="debug" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/core/src/test/java/com/github/jasjisdo/lemonad/ForTest.java
+++ b/core/src/test/java/com/github/jasjisdo/lemonad/ForTest.java
@@ -2,6 +2,8 @@ package com.github.jasjisdo.lemonad;
 
 
 import com.github.jasjisdo.lemonad.loop.For;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -11,10 +13,12 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
 public class ForTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ForTest.class);
 
     private final List<String> stringList = new ArrayList<>();
     private final Predicate<String> isNotEmpty = s -> !s.isEmpty();
@@ -32,6 +36,8 @@ public class ForTest {
         stringList.add("Joe2");
         stringList.add("Doe1");
         stringList.add("Doe2");
+
+        logger.info("created stringList = {}", stringList);
 
     }
 

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<configuration>
+<!--    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />-->
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} [%C{36}#%M\(\)] - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="com.github.jasjisdo" level="debug" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,21 @@
             -->
 
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
-                <version>1.2.17</version>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-core</artifactId>
+                <version>1.2.9</version>
+            </dependency>
+
+            <dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.9</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.32</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- replaces log4j dependencies with logback dependencies.
- adds slf4j api dependency
- adds logback.xml to classpath.
- adds logback-test.xml to classpath.
- adds info log message when stringList is created during unit test setup.